### PR TITLE
Fix Traefik proxy trust breaking after container restarts

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -9,10 +9,9 @@ frontend:
 http:
   use_x_forwarded_for: true
   trusted_proxies:
-    #- 172.30.33.3 # ?
     - 127.0.0.1
     - ::1
-    - 172.19.0.7
+    - 172.16.0.0/12  # Docker networks (covers all 172.16-31.x.x ranges)
 #   base_url: example.duckdns.org:8123
 mobile_app:
 


### PR DESCRIPTION
## Summary
- Replace hardcoded Traefik container IP (`172.19.0.7`) in `trusted_proxies` with the Docker subnet range `172.16.0.0/12`
- Docker reassigns container IPs on restart, causing the `X-Forwarded-For` header to be rejected by HA after every restart

## Test plan
- [ ] Restart Home Assistant and Traefik
- [ ] Confirm no `Received X-Forwarded-For header from an untrusted proxy` warnings in HA logs
- [ ] Confirm real client IPs are correctly forwarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)