### PR TITLE
Replace deprecated UVC camera with generic RTSP stream

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -239,5 +239,5 @@ input_boolean: !include input_booleans.yaml
 
 camera:
   - platform: generic
-    name: "UVC G3 Flex"
-    stream_source: "rtsp://192.168.1.9:7447/0786a7f8-2c91-4d94-9523-83c4dbf2fee0"
+    name: "Bílaplan"
+    stream_source: "rtsp://192.168.1.9:7447/631cf01736b0e0424e3aac17_0"

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -241,7 +241,3 @@ camera:
   - platform: generic
     name: "UVC G3 Flex"
     stream_source: "rtsp://192.168.1.9:7447/0786a7f8-2c91-4d94-9523-83c4dbf2fee0"
-    # still_image_url uses a secret for the full URL including API key
-    # Add to secrets.yaml: uvc_snapshot_url: http://192.168.1.9:7080/api/2.0/snapshot/camera/0786a7f8-2c91-4d94-9523-83c4dbf2fee0?force=true&apiKey=YOUR_API_KEY
-    still_image_url: !secret uvc_snapshot_url
-    verify_ssl: false

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -238,7 +238,10 @@ webhook:
 input_boolean: !include input_booleans.yaml
 
 camera:
-  - platform: uvc
-    nvr: 192.168.1.225
-    key: !secret uvc-apikey
-    password: !secret uvc-camerapass
+  - platform: generic
+    name: "UVC G3 Flex"
+    stream_source: "rtsp://192.168.1.9:7447/0786a7f8-2c91-4d94-9523-83c4dbf2fee0"
+    # still_image_url uses a secret for the full URL including API key
+    # Add to secrets.yaml: uvc_snapshot_url: http://192.168.1.9:7080/api/2.0/snapshot/camera/0786a7f8-2c91-4d94-9523-83c4dbf2fee0?force=true&apiKey=YOUR_API_KEY
+    still_image_url: !secret uvc_snapshot_url
+    verify_ssl: false


### PR DESCRIPTION
## Summary
- Replace removed `camera: platform: uvc` with `camera: platform: generic`
- Uses RTSP stream from UniFi Video NVR directly (UVC G3 Flex at NVR 192.168.1.9)
- Camera ID: `0786a7f8-2c91-4d94-9523-83c4dbf2fee0`

## Action required before merging
Add the following to `secrets.yaml`:
```
uvc_snapshot_url: http://192.168.1.9:7080/api/2.0/snapshot/camera/0786a7f8-2c91-4d94-9523-83c4dbf2fee0?force=true&apiKey=YOUR_API_KEY
```
Get the API key from the UniFi Video web UI under Settings → Users → your user.

Note: if the snapshot URL doesn't work, remove the `still_image_url` line — HA can pull stills from the RTSP stream directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)