### PR TITLE
Disable flux switch (Zigbee flooding fix)

### DIFF
--- a/switches.yaml
+++ b/switches.yaml
@@ -1,4 +1,4 @@
-- platform: flux
+# - platform: flux
   lights:
     - light.forstofa
     - light.bilskur


### PR DESCRIPTION
## Summary
- Commented out the `flux` switch platform in `switches.yaml`
- Flux was sending `color_temp` commands to all lights every 120 seconds, overwhelming the ConBee II Zigbee coordinator with `NwkRouteDiscoveryFailed` errors and causing devices to go unavailable

## Next steps
- Set up [Adaptive Lighting](https://github.com/basnijholt/adaptive-lighting) via HACS as a replacement for flux

🤖 Generated with [Claude Code](https://claude.com/claude-code)