### PR TITLE
Fix template entity IDs and add stairs automation

### DIFF
--- a/automations/lights/stairs.yaml
+++ b/automations/lights/stairs.yaml
@@ -1,0 +1,11 @@
+- alias: Stairs lights always start at 30%
+  initial_state: 'on'
+  trigger:
+    platform: state
+    entity_id: light.stigi_lights_zigbee_group
+    to: 'on'
+  action:
+    service: light.turn_on
+    data:
+      entity_id: light.stigi_lights_zigbee_group
+      brightness_pct: 30

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -147,10 +147,10 @@ binary_sensor:
 # Template binary sensors (replaces deprecated binary_sensor: platform: template)
 template:
   - binary_sensor:
-      - name: “Bílskúr hreyfing”
+      - name: “garage motion”
         device_class: motion
         state: “{{ is_state('group.garage_motion', 'on') }}”
-      - name: “Gangur hreyfing”
+      - name: “hallway motion”
         device_class: motion
         state: “{{ is_state('group.hallway_motion', 'on') }}”
 

--- a/customize.yaml
+++ b/customize.yaml
@@ -23,3 +23,9 @@ device_tracker.xiaomi_gateway:
 light.stairs:
   icon: mdi:stairs
   friendly_name: Stigi
+binary_sensor.garage_motion:
+  friendly_name: Bílskúr hreyfing
+  icon: mdi:motion-sensor
+binary_sensor.hallway_motion:
+  friendly_name: Gangur hreyfing
+  icon: mdi:motion-sensor


### PR DESCRIPTION
## Summary

- Fix template binary sensor names to preserve original entity IDs (`binary_sensor.garage_motion`, `binary_sensor.hallway_motion`) — previous names generated wrong IDs and broke dashboard references
- Add Icelandic friendly names and motion sensor icons via `customize.yaml`
- Add automation to set stairs Zigbee group (`light.stigi_lights_zigbee_group`) to 30% brightness on turn on

## Test plan

- [ ] Verify `binary_sensor.garage_motion` and `binary_sensor.hallway_motion` appear correctly in HA after restart
- [ ] Verify motion sensors show "Bílskúr hreyfing" and "Gangur hreyfing" as friendly names
- [ ] Turn on stairs lights and confirm they start at 30% brightness

🤖 Generated with [Claude Code](https://claude.com/claude-code)