### PR TITLE
Restore office lights button automation

### DIFF
--- a/automations/buttons/office_lights.yaml
+++ b/automations/buttons/office_lights.yaml
@@ -1,0 +1,35 @@
+- id: '1671135850098'
+  alias: Office lights
+  description: ''
+  trigger:
+  - platform: device
+    domain: mqtt
+    device_id: eecc76532a424fd3902418a9453b2ec4
+    type: action
+    subtype: single_left
+    discovery_id: 0x00158d000237e77d action_single_left
+  - platform: device
+    domain: mqtt
+    device_id: eecc76532a424fd3902418a9453b2ec4
+    type: click
+    subtype: left
+    discovery_id: 0x00158d000237e77d click_left
+  - platform: device
+    domain: mqtt
+    device_id: eecc76532a424fd3902418a9453b2ec4
+    type: click
+    subtype: right
+    discovery_id: 0x00158d000237e77d click_right
+  - platform: device
+    domain: mqtt
+    device_id: eecc76532a424fd3902418a9453b2ec4
+    type: action
+    subtype: single_right
+    discovery_id: 0x00158d000237e77d action_single_right
+  condition: []
+  action:
+  - type: toggle
+    device_id: 11339d5c37f44bfcba682ffb52f60d42
+    entity_id: light.garage_ofiice
+    domain: light
+  mode: single


### PR DESCRIPTION
## Summary

- Restores the missing automation for the wireless double button (`0x00158d000237e77d`) that toggles `light.garage_ofiice` on left/right click
- This was previously a UI-created automation that got lost — now tracked in YAML

## Test plan

- [ ] Press left or right button and confirm office light toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)